### PR TITLE
Add profiling

### DIFF
--- a/app/airq/__init__.py
+++ b/app/airq/__init__.py
@@ -39,9 +39,11 @@ app = Flask(__name__)
 
 # We have to use this `setattr` hack here or Mypy gets really confused.
 # See https://github.com/python/mypy/issues/2427 for details.
-setattr(app, 'wsgi_app', middleware.LoggingMiddleware(app.wsgi_app))
+setattr(app, "wsgi_app", middleware.LoggingMiddleware(app.wsgi_app))
 if os.getenv("FLASK_ENV") == "development":
-    setattr(app, 'wsgi_app', middleware.ProfilerMiddleware(app.wsgi_app, restrictions=[30]))
+    setattr(
+        app, "wsgi_app", middleware.ProfilerMiddleware(app.wsgi_app, restrictions=[30])
+    )
 
 config = {
     "CACHE_TYPE": "memcached",

--- a/app/airq/__init__.py
+++ b/app/airq/__init__.py
@@ -36,7 +36,13 @@ from airq import util
 
 
 app = Flask(__name__)
-app.wsgi_app = middleware.LoggingMiddleware(app.wsgi_app)  # type: ignore
+
+# We have to use this `setattr` hack here or Mypy gets really confused.
+# See https://github.com/python/mypy/issues/2427 for details.
+setattr(app, 'wsgi_app', middleware.LoggingMiddleware(app.wsgi_app))
+if os.getenv("FLASK_ENV") == "development":
+    setattr(app, 'wsgi_app', middleware.ProfilerMiddleware(app.wsgi_app, restrictions=[30]))
+
 config = {
     "CACHE_TYPE": "memcached",
     "CACHE_DEFAULT_TIMEOUT": 300,

--- a/app/airq/middleware.py
+++ b/app/airq/middleware.py
@@ -1,6 +1,13 @@
 import json
 import logging
 import time
+import urllib
+
+from werkzeug.middleware import profiler
+
+#
+# TODO: Figure out how to add typing to this file.
+#
 
 
 logger = logging.getLogger(__name__)
@@ -32,3 +39,19 @@ class LoggingMiddleware:
             return start_response(status, headers, exc_info)
 
         return self.app(environ, _start_response)
+
+
+class ProfilerMiddleware(profiler.ProfilerMiddleware):
+    """A version of Werkzeug's ProfilerMiddleware which only
+    profiles a request when profile=1 is set in the query string;
+    e.g., localhost:5000/quality?zipcode=94703&profile=1
+    """
+
+    def __call__(self, environ, start_response):
+        query_string = environ.get("QUERY_STRING", "")
+        args = urllib.parse.parse_qs(query_string)
+        if args.get("profile"):
+            # Profile the response.
+            return super().__call__(environ, start_response)
+        # Just do the default behavior; no profiling.
+        return self._app(environ, start_response)


### PR DESCRIPTION
Adds the ability to profile web requests using Python's built-in cProfile module. 

Profiling is only available in development. To profile a request, add `?profile=1` to the URL. Profile results will be printed to the console. 

Here are some example results: 
```
app_1        | PATH: '/quality'
app_1        |          118946 function calls (118730 primitive calls) in 3.573 seconds
app_1        | 
app_1        |    Ordered by: internal time, call count
app_1        | 
app_1        |    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
app_1        |       916    1.292    0.001    1.292    0.001 {method 'read' of '_ssl._SSLSocket' objects}
app_1        |         6    0.319    0.053    0.662    0.110 /usr/local/lib/python3.8/site-packages/urllib3/util/url.py:210(_encode_invalid_chars)
app_1        |        12    0.187    0.016    0.187    0.016 {method 'execute' of 'sqlite3.Cursor' objects}
app_1        |         2    0.175    0.088    0.175    0.088 {method 'set_multi' of 'client' objects}
app_1        |         1    0.153    0.153    3.615    3.615 /home/app/app/airq/air_quality.py:41(get_metrics_for_zipcode)
app_1        |     19259    0.124    0.000    0.124    0.000 {built-in method builtins.ord}
app_1        |     17609    0.115    0.000    0.115    0.000 {method 'decode' of 'bytes' objects}
app_1        |         1    0.070    0.070    0.246    0.246 /home/app/app/airq/geodb.py:81(get_sensors_for_zipcodes)
app_1        |        11    0.066    0.006    0.066    0.006 {method 'fetchall' of 'sqlite3.Cursor' objects}
app_1        |      7536    0.048    0.000    0.048    0.000 {method 'append' of 'list' objects}
app_1        | 5907/5904    0.043    0.000    0.043    0.000 {built-in method builtins.len}
app_1        |      5700    0.040    0.000    0.040    0.000 {method 'get' of 'dict' objects}
app_1        |      1756    0.038    0.000    0.062    0.000 /usr/local/lib/python3.8/site-packages/urllib3/util/url.py:223(<lambda>)
app_1        |         2    0.037    0.019    0.081    0.040 /usr/local/lib/python3.8/site-packages/flask_caching/backends/memcache.py:112(get_dict)
app_1        |       215    0.037    0.000    0.071    0.000 {built-in method builtins.sorted}
app_1        |      4864    0.035    0.000    0.035    0.000 {built-in method __new__ of type object at 0x7f69a8097940}
app_1        |       916    0.032    0.000    1.369    0.001 /usr/local/lib/python3.8/ssl.py:1230(recv_into)
app_1        |      4646    0.032    0.000    0.032    0.000 /home/app/app/airq/air_quality.py:69(<lambda>)
app_1        |       916    0.032    0.000    1.433    0.002 /usr/local/lib/python3.8/socket.py:655(readinto)
app_1        |      4646    0.030    0.000    0.030    0.000 {method 'add' of 'set' objects}
app_1        |         1    0.027    0.027    2.624    2.624 /home/app/app/airq/purpleair.py:33(_get_pm25_readings_from_api)
app_1        |         1    0.025    0.025    0.025    0.025 {method 'do_handshake' of '_ssl._SSLSocket' objects}
app_1        |         1    0.023    0.023    0.041    0.041 /usr/local/lib/python3.8/site-packages/requests/utils.py:570(unquote_unreserved)
app_1        |       916    0.023    0.000    1.322    0.001 /usr/local/lib/python3.8/ssl.py:1090(read)
app_1        |      2808    0.022    0.000    0.022    0.000 {built-in method builtins.min}
app_1        |      2803    0.022    0.000    0.022    0.000 {built-in method builtins.max}
app_1        |      2637    0.021    0.000    0.021    0.000 /usr/local/lib/python3.8/site-packages/flask_caching/backends/memcache.py:78(_normalize_key)
app_1        |      2637    0.020    0.000    0.020    0.000 /home/app/app/airq/cache.py:20(_make_key)
app_1        |         1    0.017    0.017    0.017    0.017 /usr/local/lib/python3.8/json/decoder.py:343(raw_decode)
app_1        |       916    0.016    0.000    0.024    0.000 {method '_checkReadable' of '_io._IOBase' objects}
app_1        |       310    0.016    0.000    0.027    0.000 /home/app/app/airq/util.py:45(haversine_distance)
app_1        |      1785    0.015    0.000    0.015    0.000 {method 'match' of 're.Pattern' objects}
app_1        |       160    0.015    0.000    0.313    0.002 /usr/local/lib/python3.8/site-packages/urllib3/response.py:480(read)
app_1        |         6    0.014    0.002    0.076    0.013 {method 'subn' of 're.Pattern' objects}
app_1        |      1835    0.014    0.000    0.014    0.000 /usr/local/lib/python3.8/ssl.py:1078(_checkClosed)
app_1        |      2127    0.014    0.000    0.018    0.000 {built-in method builtins.isinstance}
app_1        |         2    0.013    0.007    0.013    0.007 {built-in method _sqlite3.connect}
```

This is *really* slow, but as you'd expect, almost all the time is spent talking to Purpleair (2.624 or 3.573 seconds). After the first request, things get better:

```
app_1        | PATH: '/quality'
app_1        |          46712 function calls (46637 primitive calls) in 0.890 seconds
app_1        | 
app_1        |    Ordered by: internal time, call count
app_1        | 
app_1        |    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
app_1        |         1    0.154    0.154    0.929    0.929 /home/app/app/airq/air_quality.py:41(get_metrics_for_zipcode)
app_1        |        12    0.114    0.010    0.114    0.010 {method 'execute' of 'sqlite3.Cursor' objects}
app_1        |         1    0.072    0.072    0.261    0.261 /home/app/app/airq/geodb.py:81(get_sensors_for_zipcodes)
app_1        |        11    0.064    0.006    0.064    0.006 {method 'fetchall' of 'sqlite3.Cursor' objects}
app_1        |      7455    0.048    0.000    0.048    0.000 {method 'append' of 'list' objects}
app_1        |      4846    0.043    0.000    0.043    0.000 {built-in method __new__ of type object at 0x7f69a8097940}
app_1        |         2    0.039    0.019    0.084    0.042 /usr/local/lib/python3.8/site-packages/flask_caching/backends/memcache.py:112(get_dict)
app_1        |       209    0.036    0.000    0.070    0.000 {built-in method builtins.sorted}
app_1        |      4646    0.031    0.000    0.031    0.000 /home/app/app/airq/air_quality.py:69(<lambda>)
app_1        |      4646    0.031    0.000    0.031    0.000 {method 'add' of 'set' objects}
app_1        |      3528    0.024    0.000    0.024    0.000 {built-in method builtins.len}
app_1        |      3027    0.022    0.000    0.022    0.000 {method 'get' of 'dict' objects}
app_1        |      2803    0.022    0.000    0.022    0.000 {built-in method builtins.min}
app_1        |      2803    0.022    0.000    0.022    0.000 {built-in method builtins.max}
app_1        |       310    0.016    0.000    0.029    0.000 /home/app/app/airq/util.py:45(haversine_distance)
app_1        |      1739    0.016    0.000    0.016    0.000 {method 'match' of 're.Pattern' objects}
app_1        |      1739    0.015    0.000    0.015    0.000 /usr/local/lib/python3.8/site-packages/flask_caching/backends/memcache.py:78(_normalize_key)
app_1        |      1739    0.013    0.000    0.013    0.000 /home/app/app/airq/cache.py:20(_make_key)
app_1        |         2    0.013    0.006    0.026    0.013 /home/app/app/airq/cache.py:38(<listcomp>)
app_1        |      1803    0.012    0.000    0.012    0.000 {built-in method builtins.isinstance}
app_1        |         2    0.008    0.004    0.008    0.004 {built-in method _sqlite3.connect}
app_1        |       728    0.006    0.000    0.006    0.000 {built-in method builtins.round}
app_1        |       363    0.005    0.000    0.010    0.000 /home/app/app/airq/air_quality.py:36(pm25_level)
app_1        |       363    0.004    0.000    0.004    0.000 /home/app/app/airq/util.py:14(from_measurement)
app_1        |       620    0.004    0.000    0.004    0.000 {built-in method math.sin}
app_1        |       620    0.004    0.000    0.004    0.000 {built-in method math.cos}
app_1        |         1    0.004    0.004    0.181    0.181 /home/app/app/airq/geodb.py:29(get_nearby_zipcodes)
app_1        |         1    0.003    0.003    0.003    0.003 {method 'close' of 'sqlite3.Connection' objects}
app_1        |         2    0.003    0.001    0.003    0.001 {method 'get_multi' of 'client' objects}
app_1        |        10    0.003    0.000    0.032    0.003 /home/app/app/airq/geodb.py:55(<listcomp>)
app_1        |       200    0.003    0.000    0.004    0.000 <string>:1(__new__)
app_1        |         1    0.003    0.003    0.012    0.012 /home/app/app/airq/__init__.py:92(<listcomp>)
app_1        |       310    0.002    0.000    0.002    0.000 {built-in method math.sqrt}
app_1        |       310    0.002    0.000    0.002    0.000 /home/app/app/airq/geodb.py:68(<lambda>)
app_1        |       310    0.002    0.000    0.002    0.000 {built-in method math.asin}
app_1        |     65/25    0.002    0.000    0.008    0.000 /usr/local/lib/python3.8/site-packages/werkzeug/local.py:300(_get_current_object)
app_1        |       182    0.002    0.000    0.002    0.000 <string>:2(__init__)
```

This request takes under 1 second and all the time spent talking to Purpleair is eliminated.

I think we can tolerate some latency here as this is an SMS-based app. People don't expect super fast responses over SMS, but we should think of some ways to speed up requests when the cache hasn't been warmed.