### PR TITLE
Automerge geodb sync only once per week

### DIFF
--- a/.github/workflows/purpleair.yml
+++ b/.github/workflows/purpleair.yml
@@ -2,7 +2,7 @@ name: Purpleair Sync
 
 on:
     schedule:
-      - cron: "0 2 * * *"
+      - cron: "0 2 * * 0"
 
 jobs:
     create_pr:


### PR DESCRIPTION
This is a github workflow which takes a branch and creates a pull request to merge changes from that branch into master. Specifically, it merges changes from the `purpleair_sync` branch, which is used to rebuild the geo database every week, into master. However, because we only rebuild the database once per week, this workflow only needs to run once per week. Therefore, I'm updating its schedule so that it runs on Sunday (day 0) every week at 2 AM, since the database gets rebuilt on Sunday at midnight.