### PR TITLE
Try to save some $$ by using a smaller Memcached node

### DIFF
--- a/app-task-definition.json
+++ b/app-task-definition.json
@@ -30,7 +30,7 @@
                 },
                 {
                     "name": "MEMCACHED_SERVERS",
-                    "value": "airq-memcached.k74xvs.0001.usw1.cache.amazonaws.com"
+                    "value": "airq-memcached-small.k74xvs.0001.usw1.cache.amazonaws.com"
                 }
             ],
             "secrets": [


### PR DESCRIPTION
As mentioned [here](https://github.com/airq-dev/airq/issues/44#issuecomment-688459872), ElastiCache is costing us something like $5/day at current load, and current load is really low. I'm using a node of type `r5.large` when I could probably get away with a `t2.small` given our memory footprint. I'm going to try making that change and see if it saves some $$.