### PR TITLE
Remove build caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,6 @@ jobs:
               uses: actions/checkout@v2
               with:
                 ref: master
-            - uses: satackey/action-docker-layer-caching@v0.0.8
-              continue-on-error: true
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@v1
               with:


### PR DESCRIPTION
Not sure why this won't work, but as it's just 1 minute of a ~15 minute deploy, it seems OK to revisit later.